### PR TITLE
"authentication credential" to replace "any means"

### DIFF
--- a/Law Enforcement Provisions/Sec. 103 a.txt
+++ b/Law Enforcement Provisions/Sec. 103 a.txt
@@ -21,8 +21,8 @@ behalf of a governmental entity;
 …
 
 (6) knowingly and willfully traffics (as defined in section 
-1029) in any password or similar information, or any other means 
-of access, knowing or having reason to know that a protected 
+1029) stolen authentication credentials, or equivalent means 
+of controlled access, knowing or having reason to know that a protected 
 computer would be accessed or damaged without authorization in a 
 manner prohibited by this section as the result of such 
 trafficking;, 


### PR DESCRIPTION
There is much criticism of line 24 because "any means" would be too vague to be reasonable, potentially criminalizing broad areas of useful research. Revision attempts to make it possible for security researchers to perform essential assessments and studies of weakness to better-inform defenders and improve security. Debate would inevitably be about what constitutes an authentication credential and controlled access, which also is helpful for security research and regulators.
